### PR TITLE
Retrieve latest version of the app from GitHub servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM java:8-jre
 
 MAINTAINER Manasi Kulkarni <mkulkarn@thoughtworks.com>, Stephen Cowley <ste@thoughtworks.com>, Joe Wright <joe@joejag.com>
 
-RUN wget https://nevergreen.io/latest
+# Get the latest release
+RUN wget $( curl https://api.github.com/repos/build-canaries/nevergreen/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4 )
 
 EXPOSE 5000
 


### PR DESCRIPTION
Docker will retrieve the latest version of the app from the GitHub servers. Nevergreen.io is down at the moment and we couldn't build our container.

The command retrieves the URL of the latest released version using GitHub API. It's a bit ugly but I couldn't find any other way of getting the latest release URL.
